### PR TITLE
Switch to RTIC v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rtic = { version = "2.0.0", features = [ "$RTIC_BACKEND" ] }
 # TODO(5) Add hal as dependency
 some-hal = "1.2.3"
 # TODO add a monotonic if you use scheduling
-# rtic-monotonics = { version = "1.0.0-alpha.2", features = [ "cortex-m-systick" ]}
+# rtic-monotonics = { version = "1.0.0", features = [ "cortex-m-systick" ]}
 
 # cargo build/run
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ defmt = { version = "0.3", features = ["encoding-rzcobs"] }
 defmt-brtt = { version = "0.1", default-features = false, features = ["rtt"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 # TODO(4) Select the correct rtic backend
-rtic = { version = "2.0.0-alpha.1", features = [ "$RTIC_BACKEND" ] }
+rtic = { version = "2.0.0", features = [ "$RTIC_BACKEND" ] }
 # TODO(5) Add hal as dependency
 some-hal = "1.2.3"
 # TODO add a monotonic if you use scheduling

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ In `Cargo.toml`, activate the correct `rtic` backend for your target by replacin
 
 ```diff
 # Cargo.toml
--rtic = { version = "2.0.0-alpha.1", features = [ "$RTIC_BACKEND" ] }
-+rtic = { version = "2.0.0-alpha.1", features = [ "thumbv7-backend" ] }
+-rtic = { version = "2.0.0", features = [ "$RTIC_BACKEND" ] }
++rtic = { version = "2.0.0", features = [ "thumbv7-backend" ] }
 ```
 
 #### 5. Add a HAL as a dependency


### PR DESCRIPTION
This template currently pulls in `rtic` in `version = "2.0.0-alpha.1"`. Since version `2.0.0` has been released a few weeks ago, I guess it is safe to update the template accordingly.

Similarly, this pull request updates `rtic-monotonics`' version from `1.0.0-alpha.2` to `1.0.0`.