### PR TITLE
Remove remaining references to probe-run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# TODO(2) replace `$CHIP` with your chip's name (see `probe-run --list-chips` output)
-runner = "probe-run --chip $CHIP"
+# TODO(2) replace `$CHIP` with your chip's name (see `probe-rs chip list` output)
+runner = "probe-rs run --chip $CHIP"
 rustflags = [
   "-C", "linker=flip-link",
   "-C", "link-arg=-Tlink.x",


### PR DESCRIPTION
Removes remaining references to `probe-run` that was left unchanged on #13 