### PR TITLE
Update the template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rtic = { version = "2.0.0", features = [ "$RTIC_BACKEND" ] }
 # TODO(5) Add hal as dependency
 some-hal = "1.2.3"
 # TODO add a monotonic if you use scheduling
-# rtic-monotonics = { version = "1.0.0", features = [ "cortex-m-systick" ]}
+# rtic-monotonics = { version = "2.0.0", features = [ "cortex-m-systick" ]}
 
 # cargo build/run
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ $ cargo install flip-link
 
 #### 2. `probe-rs`:
 
-``` console
-$ cargo install probe-rs --features cli
-```
+[Installation instructions on probe.rs](https://probe.rs/docs/getting-started/installation/)
 
 ## Setup
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly"
-components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
+components = [ "rust-src", "rustfmt", "llvm-tools" ]

--- a/src/bin/minimal.rs
+++ b/src/bin/minimal.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#[allow(unused_imports)]
 
 use test_app as _; // global logger + panicking-behavior + memory layout
 

--- a/src/bin/minimal.rs
+++ b/src/bin/minimal.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(type_alias_impl_trait)]
 
 use test_app as _; // global logger + panicking-behavior + memory layout
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_main]
 #![no_std]
-
+#[allow(unused_imports)]
 use core::sync::atomic::{AtomicUsize, Ordering};
 use defmt_brtt as _; // global logger
 


### PR DESCRIPTION
- Nightly toolchain is no longer needed
- `rtic-monotonics` is now at 2.0.0
- Update README.md to remove references to nightly and update `probe-rs` install instructions
- Add `#[allow(unused_imports)]` to disable warnings for imports of hal, panic, etc.